### PR TITLE
Use short array syntax / ::class syntax in annotations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 
 language: php
 
+sudo: false
+
 php:
   - 5.4
   - 5.5
@@ -15,7 +17,7 @@ matrix:
     - php: nightly
 
 before_script:
-  - wget 'https://github.com/xp-framework/xp-runners/releases/download/v5.2.0/setup' -O - | php
+  - wget 'https://github.com/xp-framework/xp-runners/releases/download/v5.5.0/setup' -O - | php
   - composer install --prefer-dist
   - echo "vendor/autoload.php" > composer.pth
   - echo "use=vendor/xp-framework/core" > xp.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ php:
 matrix:
   allow_failures:
     - php: hhvm
-    - php: nightly
 
 before_script:
   - wget 'https://github.com/xp-framework/xp-runners/releases/download/v5.5.0/setup' -O - | php

--- a/src/main/php/io/archive/zip/AbstractZipReaderImpl.class.php
+++ b/src/main/php/io/archive/zip/AbstractZipReaderImpl.class.php
@@ -14,7 +14,7 @@ abstract class AbstractZipReaderImpl extends \lang\Object {
   public $skip= 0;
 
   protected $stream= null;
-  protected $index= array();
+  protected $index= [];
   protected $password= null;
   protected $position= 0;
 
@@ -179,8 +179,8 @@ abstract class AbstractZipReaderImpl extends \lang\Object {
           // it as-is. Do this as certain vendors (Java e.g.) always use utf-8 
           // but do not indicate this via EFS.
           $decoded= $this->decodeName($name, $header['flags'] & 2048
-            ? array('utf-8' => \xp::ENCODING)
-            : array('utf-8' => \xp::ENCODING, 'cp437' => 'iso-8859-1', 'cp1252' => \xp::ENCODING)
+            ? ['utf-8' => \xp::ENCODING]
+            : ['utf-8' => \xp::ENCODING, 'cp437' => 'iso-8859-1', 'cp1252' => \xp::ENCODING]
           );
         }
         $extra= $this->streamRead($header['extralen']);

--- a/src/main/php/io/archive/zip/CipheringZipFileOutputStream.class.php
+++ b/src/main/php/io/archive/zip/CipheringZipFileOutputStream.class.php
@@ -46,7 +46,7 @@ class CipheringZipFileOutputStream extends \lang\Object implements OutputStream 
    */
   public function withCompression(Compression $compression, $level= 6) {
     $this->data= new MemoryOutputStream();
-    $this->compression= array($compression, $level);
+    $this->compression= [$compression, $level];
     return $this;
   }
   

--- a/src/main/php/io/archive/zip/Compression.class.php
+++ b/src/main/php/io/archive/zip/Compression.class.php
@@ -43,7 +43,7 @@ abstract class Compression extends Enum {
   public static $NONE, $GZ, $BZ;
   
   static function __static() {
-    self::$NONE= newinstance(__CLASS__, array(0, 'NONE'), '{
+    self::$NONE= newinstance(__CLASS__, [0, 'NONE'], '{
       static function __static() { }
       
       public function getCompressionStream(\io\streams\OutputStream $out, $level= 6) {
@@ -54,7 +54,7 @@ abstract class Compression extends Enum {
         return $in;
       }
     }');
-    self::$GZ= newinstance(__CLASS__, array(8, 'GZ'), '{
+    self::$GZ= newinstance(__CLASS__, [8, 'GZ'], '{
       static function __static() { }
       
       public function getCompressionStream(\io\streams\OutputStream $out, $level= 6) {
@@ -65,7 +65,7 @@ abstract class Compression extends Enum {
         return new \io\streams\InflatingInputStream($in);
       }
     }');
-    self::$BZ= newinstance(__CLASS__, array(12, 'BZ'), '{
+    self::$BZ= newinstance(__CLASS__, [12, 'BZ'], '{
       static function __static() { }
       
       public function getCompressionStream(\io\streams\OutputStream $out, $level= 6) {

--- a/src/main/php/io/archive/zip/ZipFileEntry.class.php
+++ b/src/main/php/io/archive/zip/ZipFileEntry.class.php
@@ -37,7 +37,7 @@ class ZipFileEntry extends \lang\Object implements ZipEntry {
     }
     $this->name= rtrim($this->name, '/');
     $this->mod= \util\Date::now();
-    $this->compression= array(Compression::$NONE, 6);
+    $this->compression= [Compression::$NONE, 6];
   }
   
   /**
@@ -83,7 +83,7 @@ class ZipFileEntry extends \lang\Object implements ZipEntry {
    * @param   io.archive.zip.Compression compression
    */
   public function setCompression(Compression $compression, $level= 6) {
-    $this->compression= array($compression, $level);
+    $this->compression= [$compression, $level];
   }
 
   /**

--- a/src/test/php/io/archive/zip/unittest/CompressionTest.class.php
+++ b/src/test/php/io/archive/zip/unittest/CompressionTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace io\archive\zip\unittest;
 
+use lang\IllegalArgumentException;
 use io\archive\zip\Compression;
 
 /**
@@ -24,7 +25,7 @@ class CompressionTest extends \unittest\TestCase {
     $this->assertEquals(Compression::$BZ, Compression::getInstance(12));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function unknownInstance() {
     Compression::getInstance(-1);
   }

--- a/src/test/php/io/archive/zip/unittest/MalformedZipFileTest.class.php
+++ b/src/test/php/io/archive/zip/unittest/MalformedZipFileTest.class.php
@@ -1,16 +1,18 @@
 <?php namespace io\archive\zip\unittest;
 
+use lang\FormatException;
+
 /**
  * TestCase for malformed zip files
  */
 class MalformedZipFileTest extends AbstractZipFileTest {
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function reading_zero_byte_long_file() {
     $this->entriesIn($this->archiveReaderFor('malformed', 'zerobytes'));
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function reading_file_with_incomplete_header() {
     $this->entriesIn($this->archiveReaderFor('malformed', 'pk'));
   }

--- a/src/test/php/io/archive/zip/unittest/ZipArchiveReaderTest.class.php
+++ b/src/test/php/io/archive/zip/unittest/ZipArchiveReaderTest.class.php
@@ -9,7 +9,7 @@ class ZipArchiveReaderTest extends AbstractZipFileTest {
 
   #[@test]
   public function close() {
-    $stream= newinstance('io.streams.InputStream', array(), '{
+    $stream= newinstance('io.streams.InputStream', [], '{
       public $closed= FALSE;
       public function read($limit= 8192) { return ""; }
       public function available() { return 0; }

--- a/src/test/php/io/archive/zip/unittest/ZipFileContentsTest.class.php
+++ b/src/test/php/io/archive/zip/unittest/ZipFileContentsTest.class.php
@@ -21,7 +21,7 @@ abstract class ZipFileContentsTest extends AbstractZipFileTest {
   #[@test]
   public function nofiles() {
     $this->assertEquals(
-      array(),
+      [],
       $this->entriesWithContentIn($this->archiveReaderFor('fixtures', 'nofiles'))
     );
   }
@@ -29,7 +29,7 @@ abstract class ZipFileContentsTest extends AbstractZipFileTest {
   #[@test]
   public function onefile() {
     $this->assertEquals(
-      array('hello.txt' => 'World'),
+      ['hello.txt' => 'World'],
       $this->entriesWithContentIn($this->archiveReaderFor('fixtures', 'onefile'))
     );
   }
@@ -37,7 +37,7 @@ abstract class ZipFileContentsTest extends AbstractZipFileTest {
   #[@test]
   public function onedir() {
     $this->assertEquals(
-      array('dir/' => null),
+      ['dir/' => null],
       $this->entriesWithContentIn($this->archiveReaderFor('fixtures', 'onedir'))
     );
   }
@@ -45,7 +45,7 @@ abstract class ZipFileContentsTest extends AbstractZipFileTest {
   #[@test]
   public function twofiles() {
     $this->assertEquals(
-      array('one.txt' => 'Eins', 'two.txt' => 'Zwei'),
+      ['one.txt' => 'Eins', 'two.txt' => 'Zwei'],
       $this->entriesWithContentIn($this->archiveReaderFor('fixtures', 'twofiles'))
     );
   }

--- a/src/test/php/io/archive/zip/unittest/ZipFileEntriesTest.class.php
+++ b/src/test/php/io/archive/zip/unittest/ZipFileEntriesTest.class.php
@@ -14,7 +14,7 @@ class ZipFileEntriesTest extends ZipFileContentsTest {
    * @return  [:string] content
    */
   protected function entriesWithContentIn(\io\archive\zip\ZipArchiveReader $zip) {
-    $entries= array();
+    $entries= [];
     foreach ($zip->entries() as $entry) {
       $entries[$entry->getName()]= $this->entryContent($entry);
     }

--- a/src/test/php/io/archive/zip/unittest/ZipFileIteratorTest.class.php
+++ b/src/test/php/io/archive/zip/unittest/ZipFileIteratorTest.class.php
@@ -1,5 +1,7 @@
 <?php namespace io\archive\zip\unittest;
 
+use util\NoSuchElementException;
+
 /**
  * Base class for testing zip file contents
  *
@@ -14,7 +16,7 @@ class ZipFileIteratorTest extends ZipFileContentsTest {
    * @return  [:string] content
    */
   protected function entriesWithContentIn(\io\archive\zip\ZipArchiveReader $zip) {
-    $entries= array();
+    $entries= [];
     for ($it= $zip->iterator(); $it->hasNext(); ) {
       $entry= $it->next();
       $entries[$entry->getName()]= $this->entryContent($entry);
@@ -27,7 +29,7 @@ class ZipFileIteratorTest extends ZipFileContentsTest {
     $this->assertFalse($this->archiveReaderFor('fixtures', 'nofiles')->iterator()->hasNext());
   }
 
-  #[@test, @expect('util.NoSuchElementException')]
+  #[@test, @expect(NoSuchElementException::class)]
   public function iterationOverEndForEmpty() {
     $this->archiveReaderFor('fixtures', 'nofiles')->iterator()->next();
   }
@@ -39,7 +41,7 @@ class ZipFileIteratorTest extends ZipFileContentsTest {
     try {
       $it->next();
       $this->fail('Expected exception not thrown', null, 'util.NoSuchElementException');
-    } catch (\util\NoSuchElementException $expected) { }
+    } catch (NoSuchElementException $expected) { }
     $this->assertFalse($it->hasNext());
   }
 

--- a/src/test/php/io/archive/zip/unittest/vendors/ZipFileVendorTest.class.php
+++ b/src/test/php/io/archive/zip/unittest/vendors/ZipFileVendorTest.class.php
@@ -14,7 +14,7 @@ abstract class ZipFileVendorTest extends \io\archive\zip\unittest\AbstractZipFil
   
   #[@test]
   public function emptyZipFile() {
-    $this->assertEquals(array(), $this->entriesIn($this->archiveReaderFor($this->vendor(), 'empty')));
+    $this->assertEquals([], $this->entriesIn($this->archiveReaderFor($this->vendor(), 'empty')));
   }
 
   #[@test]


### PR DESCRIPTION
Converted using [this unperfect script](https://gist.github.com/thekid/d87c0db1f5902af26c4f) using PHP 5.4 mode
