### PR TITLE
Support listing entries without password

### DIFF
--- a/src/main/php/io/archive/zip/AbstractZipReaderImpl.class.php
+++ b/src/main/php/io/archive/zip/AbstractZipReaderImpl.class.php
@@ -240,6 +240,7 @@ abstract class AbstractZipReaderImpl {
             }
 
             // Verify password
+            $stream->seek(0);
             $salt= $stream->read($sl);
             $pvv= $stream->read(2);
             $dk= hash_pbkdf2('sha1', $this->password->reveal(), $salt, 1000, 2 * $dl + 2, true);
@@ -260,6 +261,7 @@ abstract class AbstractZipReaderImpl {
             }
 
             // Verify password
+            $stream->seek(0);
             $cipher= new ZipCipher();
             $cipher->initialize(iconv(\xp::ENCODING, 'cp437', $this->password->reveal()));
             $preamble= $cipher->decipher($stream->read(12));
@@ -270,7 +272,10 @@ abstract class AbstractZipReaderImpl {
             return new DecipheringInputStream($stream, $cipher);
           };
         } else {
-          $is= function() use($stream) { return $stream; };
+          $is= function() use($stream) {
+            $stream->seek(0);
+            return $stream;
+          };
         }
         
         // Create ZipEntry object and return it

--- a/src/main/php/io/archive/zip/AbstractZipReaderImpl.class.php
+++ b/src/main/php/io/archive/zip/AbstractZipReaderImpl.class.php
@@ -221,9 +221,10 @@ abstract class AbstractZipReaderImpl {
           $this->skip= $header['compressed'] + 16;
         }
 
+        $stream= new ZipFileInputStream($this, $this->position, $header['compressed']);
+
         // AES vs. traditional PKZIP cipher
         if (99 === $header['compression']) {
-          $stream= new ZipFileInputStream($this, $this->position, $header['compressed']);
           $aes= unpack('vheader/vsize/vversion/a2vendor/cstrength/vcompression', $extra);
           $header['compression']= $aes['compression'];
           $is= function() use($header, $stream, $aes) {
@@ -253,7 +254,6 @@ abstract class AbstractZipReaderImpl {
             );
           };
         } else if ($header['flags'] & 1) {
-          $stream= new ZipFileInputStream($this, $this->position, $header['compressed']);
           $is= function() use($header, $stream) {
             if (null === $this->password) {
               throw new IllegalAccessException('No password set');
@@ -270,7 +270,6 @@ abstract class AbstractZipReaderImpl {
             return new DecipheringInputStream($stream, $cipher);
           };
         } else {
-          $stream= new ZipFileInputStream($this, $this->position, $header['compressed']);
           $is= function() use($stream) { return $stream; };
         }
         

--- a/src/main/php/io/archive/zip/SequentialZipReaderImpl.class.php
+++ b/src/main/php/io/archive/zip/SequentialZipReaderImpl.class.php
@@ -1,7 +1,7 @@
 <?php namespace io\archive\zip;
 
 use io\streams\Seekable;
-use lang\{IllegalArgumentException, IllegalStateException};
+use lang\IllegalStateException;
 
 /** Zip archive reader that works on any input stream */
 class SequentialZipReaderImpl extends AbstractZipReaderImpl {
@@ -37,6 +37,6 @@ class SequentialZipReaderImpl extends AbstractZipReaderImpl {
    * @param   int whence
    */
   protected function streamSeek($offset, $whence) {
-    throw new IllegalArgumentException('Stream not seekable');
+    throw new IllegalStateException('Stream not seekable');
   }
 }

--- a/src/main/php/io/archive/zip/ZipFileEntry.class.php
+++ b/src/main/php/io/archive/zip/ZipFileEntry.class.php
@@ -117,7 +117,7 @@ class ZipFileEntry implements ZipEntry {
    * @return  io.streams.InputStream
    */
   public function in() {
-    return $this->compression[0]->getDecompressionStream($this->is);
+    return $this->compression[0]->getDecompressionStream(($this->is)());
   }
 
   /**

--- a/src/main/php/io/archive/zip/ZipFileInputStream.class.php
+++ b/src/main/php/io/archive/zip/ZipFileInputStream.class.php
@@ -8,18 +8,15 @@ use io\streams\InputStream;
  * certain length.
  */
 class ZipFileInputStream implements InputStream {
-  protected 
-    $reader      = null,
-    $start       = 0,
-    $pos         = 0,
-    $length      = 0;
+  protected $reader, $start, $length;
+  protected $pos= 0;
 
   /**
    * Constructor
    *
-   * @param   io.archive.zip.AbstractZipReaderImpl reader
-   * @param   int start
-   * @param   int length
+   * @param  io.archive.zip.AbstractZipReaderImpl $reader
+   * @param  int $start
+   * @param  int $length
    */
   public function __construct(AbstractZipReaderImpl $reader, $start, $length) {
     $this->reader= $reader;
@@ -30,8 +27,9 @@ class ZipFileInputStream implements InputStream {
   /**
    * Read a string
    *
-   * @param   int limit default 8192
-   * @return  string
+   * @param  int $limit default 8192
+   * @return string
+   * @throws io.IOException on EOF
    */
   public function read($limit= 8192) {
     if (0 === $this->pos) {
@@ -39,7 +37,8 @@ class ZipFileInputStream implements InputStream {
     } else if ($this->pos >= $this->length) {
       throw new IOException('EOF');
     }
-    $chunk= $this->reader->streamRead(min($limit, $this->length- $this->pos));
+
+    $chunk= $this->reader->streamRead(min($limit, $this->length - $this->pos));
     $l= strlen($chunk);
     $this->pos+= $l;
     $this->reader->skip-= $l;
@@ -50,6 +49,7 @@ class ZipFileInputStream implements InputStream {
    * Returns the number of bytes that can be read from this stream 
    * without blocking.
    *
+   * @return int
    */
   public function available() {
     return $this->pos < $this->length ? $this->reader->streamAvailable() : 0;
@@ -58,6 +58,7 @@ class ZipFileInputStream implements InputStream {
   /**
    * Close this buffer
    *
+   * @return void
    */
   public function close() {
     // NOOP, leave underlying stream open


### PR DESCRIPTION
This pull request defers veryfying a password is set and is correct until *actually* extracting a file. As long as the entries' input streams are not accessed via *in()*, everything works without supplying passwords.

```php
use io\archive\zip\ZipFile;
use util\cmd\Console;

$zip= ZipFile::open($argv[1]);
foreach ($zip->entries() as $entry) {
  Console::writeLine($entry);

  // Here we would get a "password missing" exception:
  // Console::writeLine($entry->in()); 
}
$zip->close();
```